### PR TITLE
 Manage quota only for containers created by Swarm #48

### DIFF
--- a/pkg/multiTenancyPlugins/quota/quota.go
+++ b/pkg/multiTenancyPlugins/quota/quota.go
@@ -82,11 +82,6 @@ func (quotaImpl *DefaultQuotaImpl) Handle(command utils.CommandEnum, cluster clu
 	case utils.CONTAINER_DELETE:
 		resourceLongID := mux.Vars(r)["name"]
 		tenant := r.Header.Get(headers.AuthZTenantIdHeaderName)
-		err := quotaMgmt.IsSwarmContainer(cluster, resourceLongID, tenant)
-		if err != nil {
-			log.Error(err)
-			return err
-		}
 		//on delete request - decrease resource usage for the tenant in quotaService and set quota container status to PENDING_DELETED
 		quotaMgmt.DecreaseQuota(resourceLongID, tenant)
 		rec := httptest.NewRecorder()

--- a/pkg/multiTenancyPlugins/quota/quotaMgmt.go
+++ b/pkg/multiTenancyPlugins/quota/quotaMgmt.go
@@ -139,20 +139,6 @@ func (quota *QuotaMgmt) DeleteContainer(tenant string, memory int64, container s
 	}
 }
 
-func (quota *QuotaMgmt) IsSwarmContainer(cluster cluster.Cluster, id string, tenant string) error {
-	containers := (cluster).Containers()
-	for _, container := range containers {
-		if container.Info.ID == id {
-			swarm := container.Config.Labels[headers.SwarmLabel]
-			if swarm != "" {
-				return nil
-			}
-		}
-		return errors.New("Not Swarm container!")
-	}
-	return errors.New("container Not exists in cluster!")
-}
-
 //on delete request - decrease resource usage for the tenant in quotaService and set quota container status to PENDING_DELETED
 func (quota *QuotaMgmt) DecreaseQuota(id string, tenant string) bool {
 	if enforceQuota != "true" {


### PR DESCRIPTION
on delete container it is checked that the id exists on quota's struct
on refresh loop check that cluster container has the swarm label added to headers: com.docker.swarm.id
