### PR TITLE
Fix for issue 49

### DIFF
--- a/pkg/multiTenancyPlugins/authorization/defaultAuthZImpl.go
+++ b/pkg/multiTenancyPlugins/authorization/defaultAuthZImpl.go
@@ -41,6 +41,10 @@ func (defaultauthZ *DefaultAuthZImpl) Handle(command string, cluster cluster.Clu
 			if err := json.NewDecoder(bytes.NewReader(reqBody)).Decode(&containerConfig); err != nil {
 				return err
 			}
+			//Disallow a user to create the special labels Swarm or K8 use
+			if r.Header.Get(headers.AuthZTenantIdHeaderName) != "" {
+				return errors.New("Not allowed to use special labels !")
+			}
 			containerConfig.Labels[headers.TenancyLabel] = r.Header.Get(headers.AuthZTenantIdHeaderName)
 
 			var buf bytes.Buffer

--- a/pkg/multiTenancyPlugins/authorization/defaultAuthZImpl.go
+++ b/pkg/multiTenancyPlugins/authorization/defaultAuthZImpl.go
@@ -41,9 +41,11 @@ func (defaultauthZ *DefaultAuthZImpl) Handle(command string, cluster cluster.Clu
 			if err := json.NewDecoder(bytes.NewReader(reqBody)).Decode(&containerConfig); err != nil {
 				return err
 			}
-			//Disallow a user to create the special labels Swarm or K8 use
-			if r.Header.Get(headers.AuthZTenantIdHeaderName) != "" {
-				return errors.New("Not allowed to use special labels !")
+			//Disallow a user to create the special labels we inject : headers.TenancyLabel
+			res := strings.Contains(string(reqBody), headers.TenancyLabel)
+			if res == true {
+				errorMessage := "Error, special label " + headers.TenancyLabel +" disallowed!"
+				return errors.New(errorMessage)
 			}
 			containerConfig.Labels[headers.TenancyLabel] = r.Header.Get(headers.AuthZTenantIdHeaderName)
 

--- a/pkg/multiTenancyPlugins/naming/nameScoping.go
+++ b/pkg/multiTenancyPlugins/naming/nameScoping.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"errors"
 
 	apitypes "github.com/docker/engine-api/types"
 	log "github.com/Sirupsen/logrus"
@@ -73,6 +74,12 @@ func (nameScoping *DefaultNameScopingImpl) Handle(command string, cluster cluste
 
 				log.Debug("Postfixing name with tenantID...")
 				newQuery = strings.Replace(r.RequestURI, r.URL.Query().Get("name"), r.URL.Query().Get("name")+r.Header.Get(headers.AuthZTenantIdHeaderName), 1)
+				//Disallow a user to create the special labels we inject : headers.OriginalNameLabel
+				res := strings.Contains(string(reqBody), headers.OriginalNameLabel)
+				if res == true {
+					errorMessage := "Error, special label " + headers.OriginalNameLabel +" disallowed!"
+					return errors.New(errorMessage)
+				}
 				containerConfig.Labels[headers.OriginalNameLabel] = r.URL.Query().Get("name")
 
 				if err := json.NewEncoder(&buf).Encode(containerConfig); err != nil {


### PR DESCRIPTION
in each plugin that injects labels check the body and return error if user inserted same label:
on DefaultAuthZImpl : var TenancyLabel = "com.swarm.tenant.0"
on nameScoping : var OriginalNameLabel = "OriginalName"
