### PR TITLE
 docker generated container names can not be referenced #65

### DIFF
--- a/pkg/multiTenancyPlugins/naming/nameScoping.go
+++ b/pkg/multiTenancyPlugins/naming/nameScoping.go
@@ -41,6 +41,7 @@ Loop:
 			break
 		} else {
 			for _, name := range container.Names {
+				name := strings.TrimPrefix(name, "/")
 				if (resourceName == name || resourceName == container.Labels[headers.OriginalNameLabel]) && container.Labels[headers.TenancyLabel] == tenantId {
 					//Match by Name - Replace to full ID
 					mux.Vars(r)["name"] = container.Info.ID


### PR DESCRIPTION
in nameScoping.go function uniquelyIdentifyContainer the name is the same with / at the prefix - just need to trim it because the comparison 
here between names - strings
