### PR TITLE
Add swarm enum(missing api's)

### DIFF
--- a/pkg/multiTenancyPlugins/apifilter/apiImplementedMap.go
+++ b/pkg/multiTenancyPlugins/apifilter/apiImplementedMap.go
@@ -6,11 +6,11 @@ var supportedAPIsMap map[utils.CommandEnum]bool
 
 func init() {
 	supportedAPIsMap = make(map[utils.CommandEnum]bool)
-//containers
+	//containers
 	supportedAPIsMap["containerscreate"] = true
 	supportedAPIsMap["containersjson"] = true
 	supportedAPIsMap["containersps"] = true
-//container
+	//container
 	supportedAPIsMap["containerstart"] = true
 	supportedAPIsMap["containerarchive"] = true
 	supportedAPIsMap["containerattach"] = true
@@ -32,9 +32,9 @@ func init() {
 	supportedAPIsMap["containertop"] = true
 	supportedAPIsMap["containerunpause"] = true
 	supportedAPIsMap["containerupdate"] = true
-	supportedAPIsMap["containerwait"] = true	
+	supportedAPIsMap["containerwait"] = true
 	supportedAPIsMap["listContainers"] = true
-//image	
+	//image
 	supportedAPIsMap["imagecommit"] = false
 	supportedAPIsMap["imagehistory"] = false
 	supportedAPIsMap["imageimport"] = false
@@ -45,39 +45,39 @@ func init() {
 	supportedAPIsMap["imagesave"] = false
 	supportedAPIsMap["imagesearch"] = false
 	supportedAPIsMap["imagetag"] = false
-//server	
+	//server
 	supportedAPIsMap["serverlogin"] = false
 	supportedAPIsMap["serverlogout"] = false
-//Network	
+	//Network
 	supportedAPIsMap["connectNetwork"] = false
 	supportedAPIsMap["createNetwork"] = true
 	supportedAPIsMap["disconnectNetwork"] = false
 	supportedAPIsMap["listNetworks"] = true
 	supportedAPIsMap["networkremove"] = false
-//Volume	
+	//Volume
 	supportedAPIsMap["createVolume"] = false
 	supportedAPIsMap["inspectVolume"] = false
 	supportedAPIsMap["listVolume"] = false
 	supportedAPIsMap["removeVolume"] = false
-//general	
+	//general
 	supportedAPIsMap["info"] = true
 	supportedAPIsMap["version"] = false
-	
-//new
-	supportedAPIsMap["ping"] = false					//_ping
-	supportedAPIsMap["listImages"] = false				//images/json	
-	supportedAPIsMap["imagesviz"] = false				//notImplementedHandler
-	supportedAPIsMap["getRepositoriesImages"] = false	//images/get	(Get a tarball containing all images)
-	supportedAPIsMap["getRepositoryImages"] = false		//images/{name:.*}/get	(Get a tarball containing all images in a repository)
-	supportedAPIsMap["inspectImage"] = false			//images/{name:.*}/json
-	supportedAPIsMap["containerstats"] = false			//containers/{name:.*}/stats
-	supportedAPIsMap["execjson"] = false				//exec/{execid:.*}/json
-	supportedAPIsMap["networkinspect"] = false			//networks/{networkid:.*}"
-	supportedAPIsMap["auth"] = false					//auth
-	supportedAPIsMap["commit"] = false					//commit
-	supportedAPIsMap["build"] = false					//build
-	supportedAPIsMap["containerresize"] = false			//containers/{name:.*}/resize
-	supportedAPIsMap["execstart"] = false				//exec/{execid:.*}/start
-	supportedAPIsMap["execresize"] = false				//exec/{execid:.*}/resize
-	//images/create:                     (Create an image) is it equal to imagepull??		
+
+	//new
+	supportedAPIsMap["ping"] = false                  //_ping
+	supportedAPIsMap["listImages"] = false            //images/json
+	supportedAPIsMap["imagesviz"] = false             //notImplementedHandler
+	supportedAPIsMap["getRepositoriesImages"] = false //images/get	(Get a tarball containing all images)
+	supportedAPIsMap["getRepositoryImages"] = false   //images/{name:.*}/get	(Get a tarball containing all images in a repository)
+	supportedAPIsMap["inspectImage"] = false          //images/{name:.*}/json
+	supportedAPIsMap["containerstats"] = false        //containers/{name:.*}/stats
+	supportedAPIsMap["execjson"] = false              //exec/{execid:.*}/json
+	supportedAPIsMap["networkinspect"] = false        //networks/{networkid:.*}"
+	supportedAPIsMap["auth"] = false                  //auth
+	supportedAPIsMap["commit"] = false                //commit
+	supportedAPIsMap["build"] = false                 //build
+	supportedAPIsMap["containerresize"] = false       //containers/{name:.*}/resize
+	supportedAPIsMap["execstart"] = false             //exec/{execid:.*}/start
+	supportedAPIsMap["execresize"] = false            //exec/{execid:.*}/resize
+	//images/create:                     (Create an image) is it equal to imagepull??
 }

--- a/pkg/multiTenancyPlugins/apifilter/apiImplementedMap.go
+++ b/pkg/multiTenancyPlugins/apifilter/apiImplementedMap.go
@@ -6,55 +6,78 @@ var supportedAPIsMap map[utils.CommandEnum]bool
 
 func init() {
 	supportedAPIsMap = make(map[utils.CommandEnum]bool)
+//containers
 	supportedAPIsMap["containerscreate"] = true
+	supportedAPIsMap["containersjson"] = true
+	supportedAPIsMap["containersps"] = true
+//container
 	supportedAPIsMap["containerstart"] = true
 	supportedAPIsMap["containerarchive"] = true
 	supportedAPIsMap["containerattach"] = true
 	supportedAPIsMap["containerbuild"] = true
-	supportedAPIsMap["imagecommit"] = false
 	supportedAPIsMap["containercopy"] = true
 	supportedAPIsMap["containerchanges"] = true
 	supportedAPIsMap["containerevents"] = false
 	supportedAPIsMap["containerexec"] = false
 	supportedAPIsMap["containerexport"] = false
-	supportedAPIsMap["imagehistory"] = false
-	supportedAPIsMap["imageimport"] = false
-	supportedAPIsMap["info"] = true
 	supportedAPIsMap["containerjson"] = true
 	supportedAPIsMap["containerrestart"] = true
 	supportedAPIsMap["containerkill"] = true
+	supportedAPIsMap["containerlogs"] = true
+	supportedAPIsMap["containerpause"] = true
+	supportedAPIsMap["containertport"] = true
+	supportedAPIsMap["containerrename"] = false
+	supportedAPIsMap["containerdelete"] = true
+	supportedAPIsMap["containerstop"] = true
+	supportedAPIsMap["containertop"] = true
+	supportedAPIsMap["containerunpause"] = true
+	supportedAPIsMap["containerupdate"] = true
+	supportedAPIsMap["containerwait"] = true	
+	supportedAPIsMap["listContainers"] = true
+//image	
+	supportedAPIsMap["imagecommit"] = false
+	supportedAPIsMap["imagehistory"] = false
+	supportedAPIsMap["imageimport"] = false
 	supportedAPIsMap["imageload"] = false
+	supportedAPIsMap["imagepull"] = false
+	supportedAPIsMap["imagepush"] = false
+	supportedAPIsMap["imageremove"] = false
+	supportedAPIsMap["imagesave"] = false
+	supportedAPIsMap["imagesearch"] = false
+	supportedAPIsMap["imagetag"] = false
+//server	
 	supportedAPIsMap["serverlogin"] = false
 	supportedAPIsMap["serverlogout"] = false
-	supportedAPIsMap["containerlogs"] = true
+//Network	
 	supportedAPIsMap["connectNetwork"] = false
 	supportedAPIsMap["createNetwork"] = true
 	supportedAPIsMap["disconnectNetwork"] = false
 	supportedAPIsMap["listNetworks"] = true
 	supportedAPIsMap["networkremove"] = false
-	supportedAPIsMap["containerpause"] = true
-	supportedAPIsMap["containertport"] = true
-	supportedAPIsMap["listContainers"] = true
-	supportedAPIsMap["imagepull"] = false
-	supportedAPIsMap["imagepush"] = false
-	supportedAPIsMap["containerrename"] = false
-	supportedAPIsMap["imageremove"] = false
-	supportedAPIsMap["containerdelete"] = true
-	supportedAPIsMap["imagesave"] = false
-	supportedAPIsMap["imagesearch"] = false
-	supportedAPIsMap["containerstart"] = true
-	supportedAPIsMap["containerstop"] = true
-	supportedAPIsMap["imagetag"] = false
-	supportedAPIsMap["containertop"] = true
-	supportedAPIsMap["containerunpause"] = true
-	supportedAPIsMap["containerupdate"] = true
-	supportedAPIsMap["version"] = false
+//Volume	
 	supportedAPIsMap["createVolume"] = false
 	supportedAPIsMap["inspectVolume"] = false
 	supportedAPIsMap["listVolume"] = false
 	supportedAPIsMap["removeVolume"] = false
-	supportedAPIsMap["containerwait"] = true
-	supportedAPIsMap["containersjson"] = true
-	supportedAPIsMap["containersps"] = true
-
+//general	
+	supportedAPIsMap["info"] = true
+	supportedAPIsMap["version"] = false
+	
+//new
+	supportedAPIsMap["ping"] = false					//_ping
+	supportedAPIsMap["listImages"] = false				//images/json	
+	supportedAPIsMap["imagesviz"] = false				//notImplementedHandler
+	supportedAPIsMap["getRepositoriesImages"] = false	//images/get	(Get a tarball containing all images)
+	supportedAPIsMap["getRepositoryImages"] = false		//images/{name:.*}/get	(Get a tarball containing all images in a repository)
+	supportedAPIsMap["inspectImage"] = false			//images/{name:.*}/json
+	supportedAPIsMap["containerstats"] = false			//containers/{name:.*}/stats
+	supportedAPIsMap["execjson"] = false				//exec/{execid:.*}/json
+	supportedAPIsMap["networkinspect"] = false			//networks/{networkid:.*}"
+	supportedAPIsMap["auth"] = false					//auth
+	supportedAPIsMap["commit"] = false					//commit
+	supportedAPIsMap["build"] = false					//build
+	supportedAPIsMap["containerresize"] = false			//containers/{name:.*}/resize
+	supportedAPIsMap["execstart"] = false				//exec/{execid:.*}/start
+	supportedAPIsMap["execresize"] = false				//exec/{execid:.*}/resize
+	//images/create:                     (Create an image) is it equal to imagepull??		
 }


### PR DESCRIPTION
i added missing swarm api's to enum. and ordered enum map
since the matching between enum map string and swarm api, i added as comment the original swarm api. i'm not sure about the last one if implemented as image pull :
//images/create:                     (Create an image) is it equal to imagepull??    
