### PR TITLE
Volume binding

### DIFF
--- a/pkg/multiTenancyPlugins/apifilter/apiImplementedMap.go
+++ b/pkg/multiTenancyPlugins/apifilter/apiImplementedMap.go
@@ -68,10 +68,10 @@ func initSupportedAPIsMap() {
 	supportedAPIsMap["networkcreate"] = true
 	supportedAPIsMap["networkdelete"] = true
 	//Volume
-	supportedAPIsMap["createVolume"] = false
-	supportedAPIsMap["inspectVolume"] = false
-	supportedAPIsMap["listVolume"] = false
-	supportedAPIsMap["removeVolume"] = false
+	supportedAPIsMap[c.VOLUME_CREATE] = true
+	supportedAPIsMap[c.VOLUME_INSPECT] = true
+	supportedAPIsMap[c.VOLUMES_LIST] = true
+	supportedAPIsMap[c.VOLUME_DELETE] = true
 
 	//general
 	supportedAPIsMap[c.INFO] = true

--- a/pkg/multiTenancyPlugins/authorization/volumes.go
+++ b/pkg/multiTenancyPlugins/authorization/volumes.go
@@ -1,0 +1,62 @@
+// volumes.go
+package authorization
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	log "github.com/Sirupsen/logrus"
+	apitypes "github.com/docker/engine-api/types"
+	"github.com/docker/swarm/pkg/multiTenancyPlugins/headers"
+	"github.com/docker/swarm/pkg/multiTenancyPlugins/utils"
+	"github.com/gorilla/mux"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+)
+
+const HOST_FS_MOUNT_NOT_ALLOWED = "Host file system mount not allowed!"
+const VOLUME_REF_NOT_AUTHORIZED = "Volume reference Not Authorized or no such resource!"
+
+func filterVolumes(r *http.Request, rec *httptest.ResponseRecorder) []byte {
+	var response apitypes.VolumesListResponse
+	if err := json.NewDecoder(bytes.NewReader(rec.Body.Bytes())).Decode(&response); err != nil {
+		log.Error(err)
+		return nil
+	}
+	var candidates []*apitypes.Volume
+	for _, volume := range response.Volumes {
+		if strings.HasSuffix(volume.Name, r.Header.Get(headers.AuthZTenantIdHeaderName)) {
+			candidates = append(candidates, volume)
+		}
+	}
+	response.Volumes = candidates
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		log.Error(err)
+		return nil
+	}
+	return buf.Bytes()
+}
+func hostFSMountCheck(tenantId string, volumeBindings []string) utils.ErrorInfo {
+	var errorInfo utils.ErrorInfo
+	for _, volumeBinding := range volumeBindings {
+		// volume binding spec should be in the format [source:]destination[:mode]
+		arr := strings.SplitN(volumeBinding, ":", 3)
+		if len(arr) > 1 {
+			if source := filepath.ToSlash(arr[0]); strings.Contains(source, "/") {
+				errorInfo.Err = errors.New(HOST_FS_MOUNT_NOT_ALLOWED)
+			}
+		}
+	}
+	return errorInfo
+
+}
+func volumeOwnershipCheck(r *http.Request, muxVolumeName string) utils.ErrorInfo {
+	var errorInfo utils.ErrorInfo
+	if !strings.HasSuffix(mux.Vars(r)[muxVolumeName], r.Header.Get(headers.AuthZTenantIdHeaderName)) {
+		errorInfo.Err = errors.New(VOLUME_REF_NOT_AUTHORIZED)
+	}
+	return errorInfo
+}

--- a/pkg/multiTenancyPlugins/naming/volumes.go
+++ b/pkg/multiTenancyPlugins/naming/volumes.go
@@ -1,0 +1,41 @@
+// volumes
+package namescoping
+
+import (
+	"errors"
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/swarm/pkg/multiTenancyPlugins/headers"
+	"github.com/gorilla/mux"
+	"net/http"
+	"strings"
+)
+
+const VOLUME_NAME_REQUIRED = "Volume name required."
+
+func getVolumeBindings(r *http.Request, volumeBindings []string) []string {
+	for i, volumeBinding := range volumeBindings {
+		// volume binding spec should be in the format [source:]destination[:mode]
+		arr := strings.SplitN(volumeBinding, ":", 3)
+		if len(arr) > 1 {
+			volumeBindings[i] = strings.Replace(volumeBindings[i], arr[0], arr[0]+r.Header.Get(headers.AuthZTenantIdHeaderName), 1)
+		}
+	}
+	return volumeBindings
+
+}
+
+func nameScopeVolumeName(r *http.Request, volumeName string) (string, error) {
+	if volumeName == "" {
+		log.Debug(VOLUME_NAME_REQUIRED)
+		return "", errors.New(VOLUME_NAME_REQUIRED)
+	}
+	return volumeName + r.Header.Get(headers.AuthZTenantIdHeaderName), nil
+}
+
+// append tenantid to volume name
+func updateVolumeName(r *http.Request, muxVolumeName string) {
+	volumeName := mux.Vars(r)[muxVolumeName] + r.Header.Get(headers.AuthZTenantIdHeaderName)
+	r.URL.Path = strings.Replace(r.URL.Path, mux.Vars(r)[muxVolumeName], volumeName, 1)
+	mux.Vars(r)[muxVolumeName] = volumeName
+	return
+}


### PR DESCRIPTION
Volume binding:
-- added support for volume binding, e.g.  create container -v
-- added volume management support:
    -- volume ls
    -- volume inspect
    -- volume rm
    -- volume create
-- bats tests for the above
note:
    This version only includes suffixing of tenant id to volume name  to accomplish both name scoping in tenant isolation.   Volume labels are not used to ear mark volumes as belonging to particular tenant.  Labels are not used since they are only available in newer releases ( release 1.11.0 and above) and label might not be available for volume binding in create container (needs investigation).  However since volumes are only identified by their name (volumes do not have IDs) appending the tenant id does provide tenant isolation.  Also a minor point we only allow volume creation when the user supplies a volume name, i.e. we don't support the case where docker generates a volume name. 
