### PR TITLE
 updating http response error in case of missing container + log indication of authZ failure for admin/support #83 

### DIFF
--- a/pkg/multiTenancyPlugins/apifilter/apiImplementedMap.go
+++ b/pkg/multiTenancyPlugins/apifilter/apiImplementedMap.go
@@ -54,7 +54,7 @@ func initSupportedAPIsMap() {
 	supportedAPIsMap["imagedelete"] = true
 	supportedAPIsMap["imagesave"] = false
 	supportedAPIsMap[c.IMAGE_SEARCH] = true
-	supportedAPIsMap[c.IMAGE_JSON] = false //inspect image
+	supportedAPIsMap[c.IMAGE_JSON] = true //inspect image
 	supportedAPIsMap["imagetag"] = false
 	supportedAPIsMap[c.IMAGES_JSON] = true //listImages
 	//server

--- a/pkg/multiTenancyPlugins/authorization/defaultAuthZImpl.go
+++ b/pkg/multiTenancyPlugins/authorization/defaultAuthZImpl.go
@@ -135,7 +135,11 @@ func (defaultauthZ *DefaultAuthZImpl) Handle(command utils.CommandEnum, cluster 
 		return defaultauthZ.nextHandler(command, cluster, w, r, swarmHandler)
 
 	case utils.NETWORK_CONNECT, utils.NETWORK_DISCONNECT:
-		if err := ConnectDisconnect(cluster, r, w); err != nil {
+		if err := ConnectDisconnect(cluster, r); err != nil {
+			if err.Error() == "No such container "{
+				http.Error(w, fmt.Sprintf("No such container "), http.StatusNotFound)
+				return errors.New(fmt.Sprint("status ",http.StatusNotFound," HTTP error: No such container"))
+			}
 			return err
 		}
 		return defaultauthZ.nextHandler(command, cluster, w, r, swarmHandler)

--- a/pkg/multiTenancyPlugins/authorization/defaultAuthZImpl.go
+++ b/pkg/multiTenancyPlugins/authorization/defaultAuthZImpl.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"fmt"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/swarm/cluster"
@@ -60,13 +61,15 @@ func (defaultauthZ *DefaultAuthZImpl) Handle(command utils.CommandEnum, cluster 
 		//In case of container json - should record and clean - consider seperating..
 	case utils.CONTAINER_START, utils.CONTAINER_STOP, utils.CONTAINER_RESTART, utils.CONTAINER_DELETE, utils.CONTAINER_WAIT, utils.CONTAINER_ARCHIVE, utils.CONTAINER_KILL, utils.CONTAINER_PAUSE, utils.CONTAINER_UNPAUSE, utils.CONTAINER_UPDATE, utils.CONTAINER_COPY, utils.CONTAINER_CHANGES, utils.CONTAINER_ATTACH, utils.CONTAINER_LOGS, utils.CONTAINER_TOP, utils.CONTAINER_STATS, utils.CONTAINER_EXEC:
 		if !utils.IsResourceOwner(cluster, r.Header.Get(headers.AuthZTenantIdHeaderName), mux.Vars(r)["name"], "container") {
-			return errors.New("Not Authorized or no such resource!")
+			http.Error(w, fmt.Sprintf("No such container "), http.StatusNotFound)
+			return errors.New(fmt.Sprint("status ",http.StatusNotFound," HTTP error: No such container"))
 		}
 		return defaultauthZ.nextHandler(command, cluster, w, r, swarmHandler)
 
 	case utils.CONTAINER_JSON:
 		if !utils.IsResourceOwner(cluster, r.Header.Get(headers.AuthZTenantIdHeaderName), mux.Vars(r)["name"], "container") {
-			return errors.New("Not Authorized or no such resource!")
+			http.Error(w, fmt.Sprintf("No such container "), http.StatusNotFound)
+			return errors.New(fmt.Sprint("status ",http.StatusNotFound," HTTP error: No such container"))
 		}
 		rec := httptest.NewRecorder()
 		if err := defaultauthZ.nextHandler(command, cluster, rec, r, swarmHandler); err != nil {
@@ -132,12 +135,12 @@ func (defaultauthZ *DefaultAuthZImpl) Handle(command utils.CommandEnum, cluster 
 		return defaultauthZ.nextHandler(command, cluster, w, r, swarmHandler)
 
 	case utils.NETWORK_CONNECT, utils.NETWORK_DISCONNECT:
-		if err := ConnectDisconnect(cluster, r); err != nil {
+		if err := ConnectDisconnect(cluster, r, w); err != nil {
 			return err
 		}
 		return defaultauthZ.nextHandler(command, cluster, w, r, swarmHandler)
 
-	case utils.INFO, utils.NETWORK_CREATE, utils.EVENTS, utils.IMAGES_JSON, utils.IMAGE_PULL, utils.IMAGE_SEARCH, utils.IMAGE_HISTORY:
+	case utils.INFO, utils.NETWORK_CREATE, utils.EVENTS, utils.IMAGES_JSON, utils.IMAGE_PULL, utils.IMAGE_SEARCH, utils.IMAGE_HISTORY, utils.IMAGE_JSON:
 		return defaultauthZ.nextHandler(command, cluster, w, r, swarmHandler)
 
 	case utils.EXEC_START, utils.EXEC_RESIZE, utils.EXEC_JSON:

--- a/pkg/multiTenancyPlugins/authorization/networks.go
+++ b/pkg/multiTenancyPlugins/authorization/networks.go
@@ -13,9 +13,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"fmt"
 )
 
-func ConnectDisconnect(cluster cluster.Cluster, r *http.Request) error {
+func ConnectDisconnect(cluster cluster.Cluster, r *http.Request, w http.ResponseWriter) error {
 	if !utils.IsResourceOwner(cluster, r.Header.Get(headers.AuthZTenantIdHeaderName), mux.Vars(r)["networkid"], "network") {
 		return errors.New("Not authorized or no such network!")
 	}
@@ -26,7 +27,8 @@ func ConnectDisconnect(cluster cluster.Cluster, r *http.Request) error {
 			return err
 		}
 		if !utils.IsResourceOwner(cluster, r.Header.Get(headers.AuthZTenantIdHeaderName), request.Container, "container") {
-			return errors.New("Not Authorized or no such container!")
+			http.Error(w, fmt.Sprintf("No such container "), http.StatusNotFound)
+			return errors.New(fmt.Sprint("status ",http.StatusNotFound," HTTP error: No such container"))
 		}
 		var buf bytes.Buffer
 		if err := json.NewEncoder(&buf).Encode(request); err != nil {

--- a/pkg/multiTenancyPlugins/authorization/networks.go
+++ b/pkg/multiTenancyPlugins/authorization/networks.go
@@ -13,10 +13,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"fmt"
+	//"fmt"
 )
 
-func ConnectDisconnect(cluster cluster.Cluster, r *http.Request, w http.ResponseWriter) error {
+func ConnectDisconnect(cluster cluster.Cluster, r *http.Request) error {
 	if !utils.IsResourceOwner(cluster, r.Header.Get(headers.AuthZTenantIdHeaderName), mux.Vars(r)["networkid"], "network") {
 		return errors.New("Not authorized or no such network!")
 	}
@@ -27,8 +27,7 @@ func ConnectDisconnect(cluster cluster.Cluster, r *http.Request, w http.Response
 			return err
 		}
 		if !utils.IsResourceOwner(cluster, r.Header.Get(headers.AuthZTenantIdHeaderName), request.Container, "container") {
-			http.Error(w, fmt.Sprintf("No such container "), http.StatusNotFound)
-			return errors.New(fmt.Sprint("status ",http.StatusNotFound," HTTP error: No such container"))
+			return errors.New("No such container ")
 		}
 		var buf bytes.Buffer
 		if err := json.NewEncoder(&buf).Encode(request); err != nil {

--- a/pkg/multiTenancyPlugins/naming/nameScoping.go
+++ b/pkg/multiTenancyPlugins/naming/nameScoping.go
@@ -115,7 +115,7 @@ func (nameScoping *DefaultNameScopingImpl) Handle(command utils.CommandEnum, clu
 		DeleteInspect(cluster, r)
 		return nameScoping.nextHandler(command, cluster, w, r, swarmHandler)
 
-	case utils.PS, utils.JSON, utils.NETWORKS_LIST, utils.INFO, utils.EVENTS, utils.IMAGES_JSON, utils.EXEC_START, utils.EXEC_RESIZE, utils.EXEC_JSON, utils.IMAGE_PULL, utils.IMAGE_SEARCH, utils.IMAGE_HISTORY:
+	case utils.PS, utils.JSON, utils.NETWORKS_LIST, utils.INFO, utils.EVENTS, utils.IMAGES_JSON, utils.EXEC_START, utils.EXEC_RESIZE, utils.EXEC_JSON, utils.IMAGE_PULL, utils.IMAGE_SEARCH, utils.IMAGE_HISTORY, utils.IMAGE_JSON:
 		return nameScoping.nextHandler(command, cluster, w, r, swarmHandler)
 
 	default:


### PR DESCRIPTION
adding image inspect

The error should be exactly the same as the regular "there is no such container" error

In the log we WILL put indication of authZ failure so that the admin/support would know
