### PR TITLE
Disallow k8s name prefix.

### DIFF
--- a/pkg/multiTenancyPlugins/authorization/defaultAuthZImpl.go
+++ b/pkg/multiTenancyPlugins/authorization/defaultAuthZImpl.go
@@ -44,9 +44,9 @@ func (defaultauthZ *DefaultAuthZImpl) Handle(command utils.CommandEnum, cluster 
 				errInfo.Err = err
 				return errInfo
 			}
-			//Disallow a user to create the special labels we inject : headers.TenancyLabel
-			if strings.Contains(string(reqBody), headers.TenancyLabel) == true {
-				errInfo.Err = errors.New("Error, special label " + headers.TenancyLabel + " not allowed!")
+			// Special constraints for container labels/name
+			if err := utils.CheckConstraints(r, string(reqBody)); err != nil {
+				errInfo.Err = err
 				return errInfo
 			}
 			// network authorization

--- a/pkg/multiTenancyPlugins/utils/utils.go
+++ b/pkg/multiTenancyPlugins/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -93,6 +94,17 @@ func CleanUpLabeling(r *http.Request, rec *httptest.ResponseRecorder) []byte {
 	log.Debugf("Clean up labeling done.")
 	//	log.Debug("Got this new body...", string(newBody))
 	return newBody
+}
+
+//
+func CheckConstraints(r *http.Request, reqBody string) error {
+	if strings.Contains(reqBody, headers.TenancyLabel) {
+		return errors.New("Special label " + headers.TenancyLabel + " not allowed")
+	}
+	if strings.HasPrefix(r.URL.Query().Get("name"), "k8s_") {
+		return errors.New("Name prefix k8s_ is not allowed")
+	}
+	return nil
 }
 
 // RandStringBytesRmndr used to generate a name for docker volume create when no name is supplied


### PR DESCRIPTION
Don't allow to create containers with name prefix 'k8s_' as it's reserved for Kubernetes.
